### PR TITLE
added the files of sp_server_facts branch on a new branch

### DIFF
--- a/plugins/module_utils/sp_server_facts.py
+++ b/plugins/module_utils/sp_server_facts.py
@@ -1,0 +1,366 @@
+import  json
+import subprocess
+
+from ..module_utils.dsmadmc_adapter import DsmadmcAdapter
+
+class DsmadmcAdapterExtended(DsmadmcAdapter):
+    """
+    Extended DsmadmcAdapter to add support for the -commadelimited parameter.
+    """
+
+    def run_command(self, command, auto_exit=True, dataonly=True, exit_on_fail=True):
+        command = (
+            f'dsmadmc -servername={self.server_name} -id={self.username} -pass={self.password} '
+            + ('-dataonly=yes ' if dataonly else '')
+            + '-commadelimited '
+            + command
+        )
+        self.json_output['command'] = command
+        try:
+            result = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            raw_output = result.stdout.decode('utf-8')
+            self.json_output['output'] = raw_output
+
+            if auto_exit:
+                self.json_output['changed'] = result.returncode == 0
+                self.exit_json(**self.json_output)
+
+            return result.returncode, raw_output, None
+        except subprocess.CalledProcessError as e:
+            if exit_on_fail:
+                self.fail_json(msg=e.stderr.decode('utf-8'), rc=e.returncode, **self.json_output)
+            return e.returncode, None, e.stderr.decode('utf-8')
+
+
+class DSMParser:
+    """
+    A class to parse various output data from the DSM system into structured formats.
+    """
+
+    @staticmethod
+    def parse_q_status(dsm_output):
+        """
+        Parses the 'q status' output into a dictionary.
+
+        Args:
+            dsm_output (str): The raw output string from the 'q status' command.
+
+        Returns:
+            dict: A dictionary with parsed key-value pairs based on the 'q status' output.
+        """
+        labels = [
+            "Monitor Status", "Status Refresh Interval (Minutes)", "Status Retention (Hours)",
+            "Monitor Message Alerts", "Alert Update Interval (Minutes)", "Alert to Email",
+            "Send Alert Summary to Administrators", "Alert from Email Address", "Alert SMTP Host",
+            "Alert SMTP Port", "Alert Active Duration (Minutes)", "Alert Inactive Duration (Minutes)",
+            "Alert Closed Duration (Minutes)", "Monitoring Admin", "Monitored Group", "Monitored Servers",
+            "At-Risk Interval for Applications", "Skipped files as At-Risk for Applications?",
+            "At-Risk Interval for Virtual Machines", "Skipped files as At-Risk for Virtual Machines?",
+            "At-Risk Interval for Systems", "Skipped files as At-Risk for Systems?"
+        ]
+
+        values = dsm_output.split(',')
+        parsed_data = dict(zip(labels, values))
+
+        return parsed_data
+
+    @staticmethod
+    def parse_q_monitorsettings(dsm_output):
+        """
+        Parses the 'q monitorsettings' output into a dictionary.
+
+        Args:
+            dsm_output (str): The raw output string from the 'q monitorsettings' command.
+
+        Returns:
+            dict: A dictionary with parsed key-value pairs based on the 'q monitorsettings' output.
+        """
+        labels = [
+            "Monitor Status", "Status Refresh Interval (Minutes)", "Status Retention (Hours)",
+            "Monitor Message Alerts", "Alert Update Interval (Minutes)", "Alert to Email",
+            "Send Alert Summary to Administrators", "Alert from Email Address", "Alert SMTP Host",
+            "Alert SMTP Port", "Alert Active Duration (Minutes)", "Alert Inactive Duration (Minutes)",
+            "Alert Closed Duration (Minutes)", "Monitoring Admin", "Monitored Group", "Monitored Servers",
+            "At-Risk Interval for Applications", "Skipped files as At-Risk for Applications?",
+            "At-Risk Interval for Virtual Machines", "Skipped files as At-Risk for Virtual Machines?",
+            "At-Risk Interval for Systems", "Skipped files as At-Risk for Systems?"
+        ]
+
+        values = dsm_output.split(',')
+        parsed_data = dict(zip(labels, values))
+
+        return parsed_data
+
+    @staticmethod
+    def parse_q_db(raw_output):
+        """
+        Parses the database information output into a structured dictionary.
+
+        Args:
+            raw_output (str): The raw output string from the database info query.
+
+        Returns:
+            dict: A dictionary with parsed database information (e.g., name, pages, usage).
+        """
+        raw_data = raw_output.splitlines()[0]
+        parsed_data = [item.strip().replace('"', '') for item in raw_data.split(",")]
+
+        parsed_output = {
+            "Database Name": parsed_data[0],
+            "Total Pages": parsed_data[1],
+            "Usable Pages": parsed_data[2],
+            "Used Pages": parsed_data[3],
+            "Free Pages": parsed_data[4]
+        }
+
+        return parsed_output
+
+    @staticmethod
+    def parse_q_dbspace(raw_output):
+        """
+        Parses the space information output into a structured dictionary.
+
+        Args:
+            raw_output (str): The raw output string from the space info query.
+
+        Returns:
+            dict: A dictionary with parsed space information (total, used, and free space).
+        """
+        parsed_values = [item.strip().replace('"', '') for item in raw_output.strip().split(",")]
+        parsed_output = {
+            "Total Space (MB)": parsed_values[0],
+            "Used Space (MB)": parsed_values[1],
+            "Free Space (MB)": parsed_values[2]
+        }
+
+        return parsed_output
+
+    def parse_q_log(raw_output):
+        """
+        Parses the space information output into a structured dictionary.
+
+        Args:
+            raw_output (str): The raw output string from the space info query.
+
+        Returns:
+            dict: A dictionary with parsed space information (total, used, and free space).
+        """
+        parsed_values = [item.strip().replace('"', '') for item in raw_output.strip().split(",")]
+        parsed_output = {
+            "Total Space (MB)": parsed_values[0],
+            "Used Space (MB)": parsed_values[1],
+            "Free Space (MB)": parsed_values[2]
+        }
+
+        return parsed_output
+
+    @staticmethod
+    def parse_q_domain(raw_output):
+        """
+        Parses the policy information output into a structured dictionary.
+
+        Args:
+            raw_output (str): The raw output string from the policy info query.
+
+        Returns:
+            dict: A dictionary with parsed policy information (e.g., domain name, nodes).
+        """
+        parsed_values = [item.strip() for item in raw_output.strip().split(",")]
+        parsed_output = {
+            "Policy Domain Name": parsed_values[0],
+            "Activated Policy Set": parsed_values[1],
+            "Activated Default Mgmt Class": parsed_values[2],
+            "Number of Registered Nodes": parsed_values[3],
+            "Description": parsed_values[4]
+        }
+
+        return parsed_output
+
+    @staticmethod
+    def parse_q_copygroup(raw_output):
+        """
+        Parses the policy settings output into a list of dictionaries.
+
+        Args:
+            raw_output (str): The raw output string from the policy settings query.
+
+        Returns:
+            list: A list of dictionaries, each containing parsed policy setting details.
+        """
+        rows = raw_output.strip().split("\n")
+        keys = [
+            "Policy Domain Name", "Policy Set Name", "Mgmt Class Name", "Copy Group Name",
+            "Versions Data Exists", "Versions Data Deleted", "Retain Extra Versions", "Retain Only Version"
+        ]
+
+        parsed_output = []
+        for row in rows:
+            values = [value.strip() for value in row.split(",")]
+            parsed_output.append(dict(zip(keys, values)))
+
+        return parsed_output
+
+    @staticmethod
+    def parse_q_replrule(raw_output):
+        """
+        Parses the replication rules output into a dictionary.
+
+        Args:
+            raw_output (str): The raw output string from the replication rules query.
+
+        Returns:
+            dict: A dictionary with parsed replication rules and a footer message.
+        """
+        rows = raw_output.strip().split("\n")
+        keys = [
+            "Replication Rule Name", "Target Replication Server", "Active Only", "Enabled"
+        ]
+        parsed_output = []
+
+        for row in rows:
+            if row.startswith("ANR1999I"):
+                continue
+            values = [value.strip() if value else None for value in row.split(",")]
+            parsed_output.append(dict(zip(keys, values)))
+
+        footer_message = "ANR1999I QUERY REPLRULE completed successfully."
+        return {"rules": parsed_output, "footer_message": footer_message}
+
+    @staticmethod
+    def parse_q_devclass(raw_output):
+        """
+        Parses the device class output into a dictionary.
+
+        Args:
+            raw_output (str): The raw output string from the device class query.
+
+        Returns:
+            dict: A dictionary with parsed device class details.
+        """
+        keys = [
+            "Device Class Name", "Device Access Strategy", "Storage Pool Count",
+            "Device Type", "Format", "Est/Max Capacity (MB)", "Mount Limit"
+        ]
+
+        values = [value.strip() if value else None for value in raw_output.strip().split(",")]
+        parsed_output = dict(zip(keys, values))
+
+        return parsed_output
+
+    @staticmethod
+    def parse_q_mgmtclass(raw_output):
+        """
+        Parses the policy management class output into a list of dictionaries.
+
+        Args:
+            raw_output (str): The raw output string from the policy management class query.
+
+        Returns:
+            list: A list of dictionaries with parsed policy management class details.
+        """
+        keys = [
+            "Policy Domain Name", "Policy Set Name", "Mgmt Class Name", "Default Mgmt Class?", "Description"
+        ]
+        rows = [line.strip() for line in raw_output.strip().split("\n") if line.strip()]
+
+        parsed_output = []
+        for row in rows:
+            values = [value.strip() for value in row.split(",")]
+            parsed_output.append(dict(zip(keys, values)))
+
+        return parsed_output
+
+    @staticmethod
+    def parse_q_stgpool(raw_output):
+        """
+        Parses the storage pool output into a list of dictionaries.
+
+        Args:
+            raw_output (str): The raw output string from the storage pool query.
+
+        Returns:
+            list: A list of dictionaries with parsed storage pool details.
+        """
+        keys = [
+            "Storage Pool Name", "Device Class Name", "Storage Type", "Estimated Capacity", "Pct Util",
+            "Pct Migr", "High Mig Pct", "Low Mig Pct", "Next Storage Pool"
+        ]
+
+        rows = [line.strip() for line in raw_output.strip().split("\n") if line.strip()]
+        parsed_output = []
+
+        for row in rows:
+            values = [value.strip() for value in row.split(",")]
+            parsed_output.append(dict(zip(keys, values)))
+
+        return parsed_output
+
+
+class SpServerResponseMapper:
+    mapping = {
+        "Copy Group Name": "copy_group_name",
+        "Mgmt Class Name": "mgmt_class_name",
+        "Policy Domain Name": "policy_domain_name",
+        "Policy Set Name": "policy_set_name",
+        "Retain Extra Versions": "retain_extra_versions",
+        "Retain Only Version": "retain_only_version",
+        "Versions Data Deleted": "versions_data_deleted",
+        "Versions Data Exists": "versions_data_exists",
+        "Free Space (MB)": "free_space_mb",
+        "Total Space (MB)": "total_space_mb",
+        "Used Space (MB)": "used_space_mb",
+        "Device Access Strategy": "device_access_strategy",
+        "Device Class Name": "device_class_name",
+        "Device Type": "device_type",
+        "Est/Max Capacity (MB)": "est_max_capacity_mb",
+        "Format": "format",
+        "Mount Limit": "mount_limit",
+        "Storage Pool Count": "storage_pool_count",
+        "Activated Default Mgmt Class": "activated_default_mgmt_class",
+        "Activated Policy Set": "activated_policy_set",
+        "Description": "description",
+        "Number of Registered Nodes": "number_of_registered_nodes",
+        "Monitor Message Alerts": "monitor_message_alerts",
+        "Monitor Status": "monitor_status",
+        "Monitored Group": "monitored_group",
+        "Monitored Servers": "monitored_servers",
+        "Monitoring Admin": "monitoring_admin",
+        "Send Alert Summary to Administrators": "send_alert_summary_to_administrators",
+        "Skipped files as At-Risk for Applications?": "skipped_files_at_risk_for_applications",
+        "Skipped files as At-Risk for Systems?": "skipped_files_at_risk_for_systems",
+        "Skipped files as At-Risk for Virtual Machines?": "skipped_files_at_risk_for_virtual_machines",
+        "Status Refresh Interval (Minutes)": "status_refresh_interval_minutes",
+        "Status Retention (Hours)": "status_retention_hours",
+        "Estimated Capacity": "estimated_capacity",
+        "High Mig Pct": "high_mig_pct",
+        "Low Mig Pct": "low_mig_pct",
+        "Next Storage Pool": "next_storage_pool",
+        "Pct Migr": "pct_migr",
+        "Pct Util": "pct_util",
+        "Storage Pool Name": "storage_pool_name",
+        "Storage Type": "storage_type",
+        "Alert Active Duration (Minutes)": "alert_active_duration_minutes",
+        "Default Mgmt Class?": "default_mgmt_class",
+        "Alert Closed Duration (Minutes)": "alert_closed_duration_min",
+        "Alert Inactive Duration (Minutes)": "alert_inactive_duration_minutes",
+        "Alert SMTP Host": "alert_smtp_host",
+        "Alert SMTP Port": "alert_smtp_port",
+        "Alert Update Interval (Minutes)": "alert_update_interval_min",
+        "Alert from Email Address": "alert_email_address",
+        "Alert to Email": "alert_email",
+        "At-Risk Interval for Applications": "at_risk_interval_applications",
+        "At-Risk Interval for Systems": "at_risk_interval_systems",
+        "At-Risk Interval for Virtual Machines": "at_risk_interval_vm",
+    }
+
+    @staticmethod
+    def map_to_developer_friendly(json_data):
+        if isinstance(json_data, dict):
+            # Recursively map each key-value pair in the dictionary
+            return {SpServerResponseMapper.mapping.get(key, key): SpServerResponseMapper.map_to_developer_friendly(value)
+                    for key, value in json_data.items()}
+        elif isinstance(json_data, list):
+            # Recursively map each item in the list
+            return [SpServerResponseMapper.map_to_developer_friendly(item) for item in json_data]
+        else:
+            return json_data

--- a/plugins/modules/sp_server_facts.py
+++ b/plugins/modules/sp_server_facts.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+from ..module_utils.sp_server_facts import DSMParser, SpServerResponseMapper
+from ..module_utils.dsmadmc_adapter import DsmadmcAdapter
+from  ..module_utils.sp_server_facts import DsmadmcAdapterExtended
+
+DOCUMENTATION = '''
+---
+module: sp_server_facts
+author: "Sarthak Kshirsagar"
+short_description: Gather IBM Storage Protect Server facts
+description:
+    - This module gathers various server facts related to the IBM Storage Protect (SP) server using the DSMADMC command-line interface.
+    - It supports multiple queries such as server status, database, monitor settings, storage pools, and more.
+    - The output of each query is parsed and returned in a developer-friendly format.
+
+options:
+    q_status:
+        description:
+            - Whether to gather status information from the server.
+        type: bool
+        default: False
+    q_monitorsettings:
+        description:
+            - Whether to gather monitor settings information from the server.
+        type: bool
+        default: False
+    q_db:
+        description:
+            - Whether to gather database information from the server.
+        type: bool
+        default: False
+    q_dbspace:
+        description:
+            - Whether to gather database space information from the server.
+        type: bool
+        default: False
+    q_log:
+        description:
+            - Whether to gather log information from the server.
+        type: bool
+        default: False
+    q_domain:
+        description:
+            - Whether to gather domain information from the server.
+        type: bool
+        default: False
+    q_copygroup:
+        description:
+            - Whether to gather copygroup information from the server.
+        type: bool
+        default: False
+    q_replrule:
+        description:
+            - Whether to gather replication rule information from the server.
+        type: bool
+        default: False
+    q_devclass:
+        description:
+            - Whether to gather device class information from the server.
+        type: bool
+        default: False
+    q_mgmtclass:
+        description:
+            - Whether to gather management class information from the server.
+        type: bool
+        default: False
+    q_stgpool:
+        description:
+            - Whether to gather storage pool information from the server.
+        type: bool
+        default: False
+extends_documentation_fragment: ibm.storage_protect.auth
+'''
+
+EXAMPLES = '''
+---
+- name: Gather server facts from IBM Storage Protect server
+  sp_server_facts:
+    q_status: true
+    q_db: true
+    q_stgpool: true
+    q_dbspace: false
+    q_log: false
+    q_domain: false
+    q_copygroup: false
+    q_replrule: false
+    q_devclass: false
+    q_mgmtclass: false
+    q_stgpool: false
+  register: sp_server_facts
+
+- name: Display results
+  debug:
+    var: sp_server_facts.results
+'''
+def main():
+    argument_spec = dict(
+        q_status=dict(type='bool', default=False),
+        q_monitorsettings=dict(type='bool', default=False),
+        q_db=dict(type='bool', default=False),
+        q_dbspace=dict(type='bool', default=False),
+        q_log=dict(type='bool', default=False),
+        q_domain=dict(type='bool', default=False),
+        q_copygroup=dict(type='bool', default=False),
+        q_replrule=dict(type='bool', default=False),
+        q_devclass=dict(type='bool', default=False),
+        q_mgmtclass=dict(type='bool', default=False),
+        q_stgpool=dict(type='bool', default=False)
+    )
+
+    results = {}
+
+    queries = [
+        'status',
+        'monitorsettings',
+        'db',
+        'dbspace',
+        'log',
+        'domain',
+        'copygroup',
+        'replrule',
+        'devclass',
+        'mgmtclass',
+        'stgpool'
+    ]
+
+    dsmadmc = DsmadmcAdapterExtended(argument_spec=argument_spec)
+    for query in queries:
+        if dsmadmc.params.get(f'q_{query}'):
+            rc, output, _ = dsmadmc.run_command(f'q {query}', auto_exit=False)
+            if rc == 0:
+                results[f'q_{query}'] = getattr(DSMParser, f'parse_q_{query}')(output)
+
+    mapped_result = SpServerResponseMapper.map_to_developer_friendly(results)
+
+    dsmadmc.exit_json(changed=False, results=mapped_result)
+
+if __name__ == '__main__':
+    main()

--- a/roles/sp_server_facts/README.md
+++ b/roles/sp_server_facts/README.md
@@ -1,0 +1,83 @@
+# Ansible Role: sp_server_facts
+
+This Ansible role is designed to retrieve the facts of a Storage Protect Server (SP) by using the `sp_server_facts` module. It gathers server information such as status, monitoring settings, storage pools, device classes, and other details. The facts collected are then displayed using Ansible's `debug` module.
+
+## Requirements
+
+- Ansible 2.9+ (to use the required features).
+- The `sp_server_facts` module must be installed and accessible.
+- Access to a running Storage Protect Server (SP) with appropriate credentials.
+
+## Environment Variables
+
+Before running the playbook, set the following environment variables in your terminal:
+
+```bash
+export STORAGE_PROTECT_SERVERNAME="your_server_name"
+export STORAGE_PROTECT_USERNAME="your_username"
+export STORAGE_PROTECT_PASSWORD="your_password"
+```
+## Role Variables
+
+### Fact Collection Configuration
+
+You can control which facts to collect using the `sp_server_facts_flags` variable. Set the corresponding keys to `true` or `false` to enable or disable specific fact collection:
+
+| Key                | Description                            | Default  |
+|--------------------|----------------------------------------|----------|
+| `q_status`         | Collect server status information     | `false`  |
+| `q_monitorsettings`| Collect monitor settings information  | `false`  |
+| `q_db`             | Collect database information          | `false`  |
+| `q_dbspace`        | Collect database space information    | `false`  |
+| `q_log`            | Collect log information               | `false`  |
+| `q_domain`         | Collect domain information            | `false`  |
+| `q_copygroup`      | Collect copy group information        | `false`  |
+| `q_replrule`       | Collect replication rule information  | `false`  |
+| `q_devclass`       | Collect device class information      | `false`  |
+| `q_mgmtclass`      | Collect management class information  | `false`  |
+| `q_stgpool`        | Collect storage pool information      | `false`  |
+
+### Example Variables for Fact Flags
+
+```yaml
+sp_server_facts_flags:
+  q_status: true
+  q_monitorsettings: false
+  q_db: true
+  q_dbspace: true
+  q_log: false
+  q_domain: false
+  q_copygroup: false
+  q_replrule: false
+  q_devclass: true
+  q_mgmtclass: false
+  q_stgpool: true
+```
+
+### Example Playbook
+
+```yaml
+- name: Get the SP Server facts
+  hosts: local
+  gather_facts: no
+  become: yes
+  environment:
+    STORAGE_PROTECT_SERVERNAME: "{{ lookup('env', 'STORAGE_PROTECT_SERVERNAME') }}"
+    STORAGE_PROTECT_USERNAME: "{{ lookup('env', 'STORAGE_PROTECT_USERNAME') }}"
+    STORAGE_PROTECT_PASSWORD: "{{ lookup('env', 'STORAGE_PROTECT_PASSWORD') }}"
+  roles:
+    - role: sp_server_facts
+      vars:
+        sp_server_facts_flags:
+          q_status: true
+          q_monitorsettings: true
+          q_db: true
+          q_dbspace: true
+          q_log: true
+          q_domain: true
+          q_copygroup: true
+          q_replrule: true
+          q_devclass: true
+          q_mgmtclass: true
+          q_stgpool: true
+

--- a/roles/sp_server_facts/defaults/main.yml
+++ b/roles/sp_server_facts/defaults/main.yml
@@ -1,0 +1,13 @@
+# Defaults for sp_server_facts role
+sp_server_facts_flags:
+  q_status: false
+  q_monitorsettings: false
+  q_db: false
+  q_dbspace: false
+  q_log: false
+  q_domain: false
+  q_copygroup: false
+  q_replrule: false
+  q_devclass: false
+  q_mgmtclass: false
+  q_stgpool: false

--- a/roles/sp_server_facts/tasks/main.yml
+++ b/roles/sp_server_facts/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+- name: "Gather Storage Protect Server Facts"
+  sp_server_facts:
+    q_status: "{{ sp_server_facts_flags.q_status }}"
+    q_monitorsettings: "{{ sp_server_facts_flags.q_monitorsettings }}"
+    q_db: "{{ sp_server_facts_flags.q_db }}"
+    q_dbspace: "{{ sp_server_facts_flags.q_dbspace }}"
+    q_log: "{{ sp_server_facts_flags.q_log }}"
+    q_domain: "{{ sp_server_facts_flags.q_domain }}"
+    q_copygroup: "{{ sp_server_facts_flags.q_copygroup }}"
+    q_replrule: "{{ sp_server_facts_flags.q_replrule }}"
+    q_devclass: "{{ sp_server_facts_flags.q_devclass }}"
+    q_mgmtclass: "{{ sp_server_facts_flags.q_mgmtclass }}"
+    q_stgpool: "{{ sp_server_facts_flags.q_stgpool }}"
+  register: sp_server_facts
+
+- name: "Display Storage Protect Server Facts"
+  debug:
+    var: sp_server_facts

--- a/tests/integration/targets/sp_server_facts/test_sp_server_facts.yml
+++ b/tests/integration/targets/sp_server_facts/test_sp_server_facts.yml
@@ -1,0 +1,24 @@
+---
+- name: Get the SP Server facts
+  hosts: all
+  gather_facts: no
+  become: yes
+  environment:
+    STORAGE_PROTECT_SERVERNAME: "{{ lookup('env', 'STORAGE_PROTECT_SERVERNAME') }}"
+    STORAGE_PROTECT_USERNAME: "{{ lookup('env', 'STORAGE_PROTECT_USERNAME') }}"
+    STORAGE_PROTECT_PASSWORD: "{{ lookup('env', 'STORAGE_PROTECT_PASSWORD') }}"
+  roles:
+    - role: sp_server_facts
+      vars:
+        sp_server_facts_flags:
+          q_status: true
+          q_monitorsettings: true
+          q_db: true
+          q_dbspace: true
+          q_log: true
+          q_domain: true
+          q_copygroup: true
+          q_replrule: true
+          q_devclass: true
+          q_mgmtclass: true
+          q_stgpool: true


### PR DESCRIPTION
## PR summary
This Ansible module is designed to retrieve the facts of a Storage Protect Server (SP) by using the `sp_server_facts` module. It gathers server information such as status, monitoring settings, storage pools, device classes, and other details. The facts collected are then displayed using Ansible's `debug` module.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ✓] The commit message follows the Commit Message Guidelines in the CONTRIBUTING.md.
- [ ✓] Tests for the changes have been added (for bug fixes / features)
- [✓ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ✓] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [✓ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
The current system lacks a dedicated Ansible module and role to retrieve facts from a Storage Protect Server (SP).

## What is the new behavior?  
This PR introduces an Ansible module named sp_server_facts, which executes dsmadmc commands on the Storage Protect (SP) server, parses the responses into JSON format, and displays the facts to users. Additionally, a role is created to demonstrate the usage of this module, complete with detailed documentation to guide users in its implementation.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ✓ ] No
