### PR TITLE
Certificate Distribution Using Ansbile From Linux SP Server to Linux

### DIFF
--- a/playbooks/cert_distribute/cert_distribute.cfg
+++ b/playbooks/cert_distribute/cert_distribute.cfg
@@ -1,0 +1,7 @@
+SP_SERVER_HOST ansible_host=<sp-server-ip> ansible_user=<sp-server-machine-user> ansible_password=<sp-server-machine-user-password>
+
+ADMIN_CLIENT_HOST ansible_host=<admin-client-ip> ansible_user=<admin-client-machine-user> ansible_password=<admin-client-machine-user-password>
+
+[SP_CLIENT_HOST]
+client01 ansible_host=<client01-ip> ansible_user=<client01-machine-user> ansible_password=<client01-machine-user-password>
+client02 ansible_host=<client02-ip> ansible_user=<client02-machine-user> ansible_password=<client02-machine-user-password>

--- a/playbooks/cert_distribute/cert_distribute.yml
+++ b/playbooks/cert_distribute/cert_distribute.yml
@@ -1,0 +1,71 @@
+---
+- name: Generate a new IBM Storage Protect server certificate by using the administrative console.
+  hosts: CERT_ADMIN_CLIENT
+  gather_facts: no
+  tasks:
+    - name: Produce a certificate label that utilizes the date time.
+      shell: "echo SP_CERT_$(date '+%b_%d_%Y_%H_%M_%S')"
+      register: "sp_server_date_time"
+
+    - name: "Print Certificate Label"
+      debug:
+        var: sp_server_date_time.stdout
+
+    - name: Create a new self-signed certificate on the IBM Storage Protect server.
+      command: 
+        chdir: /opt/tivoli/tsm/client/ba/bin/
+        cmd: "dsmadmc -id={{ lookup('ini', 'SP_SERVER_USERNAME', file='data.ini') }} -password={{ lookup('ini', 'SP_SERVER_PASSWORD', file='data.ini') }} \"create certificate \\\"{{ sp_server_date_time.stdout }}\\\"\""
+      register: cert_info
+
+    - name: Display the output from the server command.
+      debug:
+        var: cert_info.stdout_lines
+
+- name: Copy the certificate from the IBM Storage Protect server instance directory to the local directory.
+  hosts: CERT_SP_SERVER
+  gather_facts: no
+  tasks:
+    - name: Acquire the exact path to the certificate file.
+      shell: "find / -name '{{ hostvars['CERT_ADMIN_CLIENT']['sp_server_date_time'].stdout }}.arm' 2>/dev/null | grep \".\""
+      register: search_result
+
+    - name: "Print out the server's certificate file location."
+      debug:
+        var: search_result.stdout
+
+    - name: Fetch the certificate file from the IBM Storage Protect Server and save it on the local computer.
+      fetch:
+        src: "{{ search_result.stdout }}"
+        dest: "{{ lookup('ini', 'LOCAL_CERT_DIR', file='data.ini') }}"
+        flat: yes
+
+- name: Distribute certificate to clients.
+  hosts: CERT_SP_CLIENTS
+  gather_facts: no
+  tasks:
+    - name: Copy the certificate to the client machine.
+      copy:
+        src: "{{ lookup('ini', 'LOCAL_CERT_DIR', file='data.ini') }}/{{ hostvars['CERT_ADMIN_CLIENT']['sp_server_date_time'].stdout }}.arm"
+        dest: /opt/tivoli/tsm/client/ba/bin/
+
+    - name: Get a valid keystore path.
+      shell: z='/dsmcert.kdb';y='/opt/tivoli/tsm/client/';a=$PASSWORDDIR\$z;b=$DSM_DIR$z;c=~'/IBM/StorageProtect/certs'$z;d=$y'ba/bin64'$z;e=$y'ba/bin'$z;f=$y'api/bin64'$z;g=$y'api/bin'$z;if [ -f $a ]; then h=$a;elif [ -f $b ]; then h=$b;elif [ -f $c ]; then h=$c;elif [ -f $d ]; then h=$d;elif [ -f $e ]; then h=$e;elif [ -f $f ]; then h=$f;else h=$g;fi;echo $h;
+      register: key_store_path
+
+    - name: Print out the path to the keystore.
+      debug:
+        var: key_store_path.stdout
+
+    - name: Using GSKIT, add a certificate to the client key-store.
+      shell: /usr/local/ibm/gsk8_64/bin/gsk8capicmd_64 -cert -add -label {{ hostvars['CERT_ADMIN_CLIENT']['sp_server_date_time'].stdout }} -file /opt/tivoli/tsm/client/ba/bin/{{ hostvars['CERT_ADMIN_CLIENT']['sp_server_date_time'].stdout }}.arm -db {{ key_store_path.stdout }} -stashed
+      register: gskit_cmd_result
+
+    - name: Verify the distribution of the certificate to the client.
+      shell: /usr/local/ibm/gsk8_64/bin/gsk8capicmd_64 -cert -list -db {{ key_store_path.stdout }} -stashed
+      register: gskit_list_grep_result
+
+    - name: Print the certificates stored in the client key store.
+      debug:
+        var: gskit_list_grep_result.stdout_lines
+
+

--- a/playbooks/cert_distribute/data.ini
+++ b/playbooks/cert_distribute/data.ini
@@ -1,0 +1,6 @@
+[global]
+# Global Variables For Ansible Based Certificate Distribution
+SP_SERVER = <sp-server-ip>
+SP_SERVER_USERNAME = <sp-server-admin-console-user>
+SP_SERVER_PASSWORD = <sp-server-admin-console-user-password>
+LOCAL_CERT_DIR = <full-path-to-local-directory-to-save-copied-certificate-from-server>


### PR DESCRIPTION
…SP Clients

## PR summary

Added the Ansible playbook to distribute the IBM Storage Protect Server certificate to clients.

**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the Commit Message Guidelines in the CONTRIBUTING.md.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
NA

## What is the new behavior?  

The proposed Ansbile playbook has multiple plays running on different set of hosts for distributing IBM Storage Protect server certificate to its connected clients.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Added a new folder named playbook containing certificate distribute folder where along with the playbook other files are also present. File data.ini contains the variables that will be used during distribution of certificate. CFG inventory file contains the IBM Storage Protect server host information along with ADMIN client and rest of the clients host information.

