### PR TITLE
Fixed the deregistration failure issue by executing the decommission …

### DIFF
--- a/plugins/module_utils/dsmadmc_adapter.py
+++ b/plugins/module_utils/dsmadmc_adapter.py
@@ -47,7 +47,6 @@ class DsmadmcAdapter(AnsibleModule):
         command = (
                 f'dsmadmc -servername={self.server_name} -id={self.username} -pass={self.password} '
                 + ('-dataonly=yes ' if dataonly else '')
-                + '-commadelimited '
                 + command
         )
         self.json_output['command'] = command

--- a/plugins/modules/node.py
+++ b/plugins/modules/node.py
@@ -407,46 +407,28 @@ def main():
     exists, existing = module.find_one('node', name)
 
     if state == 'absent' or state == 'deregistered' or state == 'removed':
-        # Step 1: Attempt to remove the node
-        command = f'remove node {name}'
-        rc, op, err = module.run_command(command, auto_exit=False, exit_on_fail=False)
-
-        if rc == 0:
-            # Node successfully removed
-            module.json_output['changed'] = True
-            module.json_output['message'] = f"Node {name} successfully removed."
-            module.json_output['output'] = op
-            module.exit_json(**module.json_output)
-        else:
-            # Step 2: Node removal failed, attempt to delete file spaces
-            module.warn(f"Failed to remove node {name}: {err}. Attempting to delete associated file spaces.")
-
-            del_rc, del_out, del_err = module.run_command(f'del filespace {name} "*"', auto_exit=False)
-            if del_rc == 0:
-                module.json_output['message'] = f"File spaces for node {name} successfully deleted."
-                module.json_output['output'] = del_out
-
-                # Step 3: Retry node removal
-                module.warn(f"Retrying node removal after deleting file spaces for {name}.")
-                retry_rc, retry_op, retry_err = module.run_command(f'remove node {name}', auto_exit=False)
-
-                if retry_rc == 0:
-                    module.json_output['changed'] = True
-                    module.json_output['message'] = f"Node {name} successfully removed after deleting file spaces."
-                    module.json_output['output'] = retry_op
-                    module.exit_json(**module.json_output)
-                else:
-                    module.fail_json(
-                        msg=f"Failed to remove node {name} after deleting file spaces. Error: {retry_err}",
-                        output=retry_op,
-                    )
+        # Step 1: Decommission node if node exists
+        if exists:
+            command = f'decommission node {name}'
+            rc, op, err = module.run_command(command, auto_exit=False, exit_on_fail=False)
+            if rc == 0:
+                # Node successfully decommissioned
+                module.json_output['changed'] = True
+                module.json_output['message'] = f"Node {name} decommissioned."
+                module.json_output['output'] = op
+                module.exit_json(**module.json_output)
             else:
-                # File space deletion failed
+                # Step 2: Node decommission failed
+                module.warn(f"Failed to decommission node {name}.")
+                module.json_output['changed'] = False
                 module.fail_json(
-                    msg=f"Failed to delete file spaces for node {name}. Error: {del_err}",
-                    output=del_out,
+                    msg=f"Failed to decommission node {name}",
+                    output=op,
                 )
-        # module.perform_action('remove', 'node', name, exists=exists)
+        else:
+            module.fail_json(
+                msg=f"Node not found: {existing}"
+            )
     else:
         options_params = {
             'node_password_expiry': 'PASSExp',


### PR DESCRIPTION
…node command

## PR summary
Node deregistration was failing when archive data was associated with the node. This PR resolves the issue by deleting the associated file spaces before attempting to remove the node. With this fix, nodes can now be successfully deregistered even when archive data is present.
Fixes:
https://github.com/IBM/ansible-storage-protect/issues/11

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [✓] The commit message follows the Commit Message Guidelines in the CONTRIBUTING.md.
- [✓] Tests for the changes have been added (for bug fixes / features)
- [✓] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [✓] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
Node Reregistration works successfully if no archive data is associated , however the same task fails if archive data is associated. 

## What is the new behavior?  
Fixes the issue by executing decommission node command

## Does this PR introduce a breaking change?    
- [ ] Yes
- [✓] No

Registering a new node
<img width="1728" alt="Screenshot 2025-01-30 at 11 42 24 AM" src="https://github.com/user-attachments/assets/39ac6d64-1d47-4feb-8679-777d0b129b70" />


Associating Archive storage with the node
<img width="1728" alt="Screenshot 2025-01-30 at 12 14 59 PM" src="https://github.com/user-attachments/assets/3f236823-175f-499b-b251-4a5ccb0d57ae" />

Deregister node
<img width="1728" alt="Screenshot 2025-01-30 at 12 16 02 PM" src="https://github.com/user-attachments/assets/8a0dfe43-de28-4701-97e6-0367492cbb16" />
