### PR TITLE
Added the role and module for taking a storage protect on-demand backup (original PR https://github.com/IBM/ansible-storage-protect/pull/20)

### DIFF
--- a/plugins/module_utils/dsmc_adapter.py
+++ b/plugins/module_utils/dsmc_adapter.py
@@ -1,0 +1,65 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule, env_fallback
+import subprocess
+
+
+class DsmcAdapter(AnsibleModule):
+    url = None
+    AUTH_ARGSPEC = dict(
+        server_name=dict(required=False, fallback=(env_fallback, ['STORAGE_PROTECT_SERVERNAME'])),
+        node_name=dict(required=False, fallback=(env_fallback, ['STORAGE_PROTECT_NODENAME'])),
+        password=dict(no_log=True, required=False, fallback=(env_fallback, ['STORAGE_PROTECT_NODE_PASSWORD'])),
+        request_timeout=dict(type='float', required=False, fallback=(env_fallback, ['STORAGE_PROTECT_REQUEST_TIMEOUT'])),
+    )
+    server_name = 'local'
+    password = None
+    validate_certs = True
+    request_timeout = 10
+    authenticated = False
+    version_checked = False
+    error_callback = None
+    warn_callback = None
+
+    def __init__(self, argument_spec=None, direct_params=None, error_callback=None, warn_callback=None, **kwargs):
+        full_argspec = {}
+        full_argspec.update(DsmcAdapter.AUTH_ARGSPEC)
+        full_argspec.update(argument_spec)
+        kwargs['supports_check_mode'] = True
+
+        self.error_callback = error_callback
+        self.warn_callback = warn_callback
+
+        self.json_output = {'changed': False}
+
+        if direct_params is not None:
+            self.params = direct_params
+        else:
+            super().__init__(argument_spec=full_argspec, **kwargs)
+
+        for param, _ in list(DsmcAdapter.AUTH_ARGSPEC.items()):
+            setattr(self, param, self.params.get(param))
+
+    def run_command(self, command):
+        command = f'dsmc {command} -se={self.server_name} -virtualnode={self.node_name} -pass={self.password} '
+        self.json_output['command'] = command
+        try:
+            result = subprocess.run(command, shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            self.json_output['changed'] = True
+            self.json_output['output'] = result.stdout.decode('utf-8')
+            self.exit_json(**self.json_output)
+            return result.returncode, result.stdout.decode('utf-8'), None
+        except subprocess.CalledProcessError as e:
+            self.json_output['changed'] = False
+            self.fail_json(msg=e.stdout.decode('utf-8') + e.stderr.decode('utf-8'), rc=e.returncode, **self.json_output)
+            return e.returncode, e.stdout.decode('utf-8'), e
+
+    def perform_action(self, action, object, options=''):
+        command = f"{action} {object} {options}"
+        rc, output, error = self.run_command(command)
+        if rc == 0:
+            self.json_output['changed'] = True
+        self.exit_json(**self.json_output)
+        return rc, output, error

--- a/plugins/modules/node_file_backup.py
+++ b/plugins/modules/node_file_backup.py
@@ -1,0 +1,156 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# (c) 2025,Amol kumar <amol.kumar2@ibm.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: node_file_backup 
+author: Amol kumar
+short_description: Take an on-demand file back-up on IBM Storage protect. 
+description:
+    - Use this module
+	(i) to perform selective backup of files or directories(with support for wildcard) characters in the specified location OR
+	(ii) to perform incremental backup of all new or changed files or directories in the specified locations.
+    - It uses the "dsmc selective" and "dsmc incremental"  CLI's for respective operations.
+options:
+    backup_action:
+        description: Type of backup to perform (selective or incremental).
+        required: true
+        type: str
+    filespec:
+        description: The paths of the files or directories to backup.Supports list of multiple files and directories, separated by a space character;in addition, 
+		     use wildcard characters to include a group of files or to include all files in a directory.
+        required: true
+        type: str
+    absolute:
+        description: Use the absolute variable with the incremental command to force a backup of all files and directories that match the file specification or domain,
+                     even if the objects were not changed since the last incremental backup.Setting to a value of "Yes" will enable the mentioned functionality. 
+        required: false
+        type: Boolean.
+    is_compression_enabled:
+        description: The compression variable compresses files before you send them to the server.Use with the incremental,and selective commands.Setting to a value
+                     of "Yes" will enable the compression. A value of "No" will ensure files are not compressed.  
+        required: false
+        type: boolean
+    is_compress_always: 
+        description: Use this variable together with is_compression_enabled. When is_compression_enabled is set to " Yes", the is_compress_always variable specifies
+                     whether to continue compressing an object if it grows during compression.Setting to a velue of "Yes" will continue to compress an object even if
+                     size of object grows after compression. Setting to a value of "No" will send the file uncompressed if the file size increases.Use with the incremental
+                     , and selective commands
+        required: false
+        type: boolean
+    diff_snapshot:
+        description: The diff_snapshot variable controls whether the backup-archive client creates the differential snapshot when it runs a snapshot difference
+                     incremental backup. Use with incremental command.If value is set to "create"  backup-archive client will create the snapshot
+                     during incremental backup. If the value it set to "latest" client will use the latest snapshot that is found on the file server as source
+                     snapshot.
+        required: false
+        type: str
+    dirs_only:
+        description: The dirs_only variable when set to "Yes" processes directories only during backup. The client does not process files. Use with incremental and
+                     selective command.
+        required: false
+        type: boolean
+    file_list:
+        description: Use the file_list variable to process a list of files. The backup-archive client opens the file you specify with this variable and processes the 
+                     list of files within according to the specific command.Use with incremental and selective command.
+        required: false
+        type: str
+    files_only:
+        description: The files_only variable when set to "Yes" restricts backup processing to files only. Use with incremental and selective comand.
+        required: false
+        type: boolean
+    remove_operand_limit:
+        description: The remove_operand_limit variable  specifies that the client removes the 20-operand limit as this limits the number of files and directories
+                     that can be specified with command.Use with incremental and selective commands.Setting the value to "Yes" will remove the limit.
+        required: false
+        type: boolean
+    snapshot_root:
+        description: Use the snapshot_root variable with the incremental, selective, commands to specify the root directory of snapshot that should be used for
+                     backup.This option is used in snapshot-supported environments. With this mechanism backup only processes snapshot data
+                     and not live filesystem.
+                     For ex : dsmc incremental /mnt/snapshot1/data -snapshotroot=/mnt/snapshot1
+        required: false
+        type: str
+    is_subdir:
+        description: The subdir variable specifies whether you want to include subdirectories of named directories for processing.If set to Yes subdirectories are processed
+		     otherwise no.Use with incremental and selective commands.
+        required: false
+        type: boolean 
+extends_documentation_fragment: ibm.storage_protect.auth
+...
+'''
+
+EXAMPLES = '''
+- name: Test On Demand backup in IBM Storage Protect
+  ibm.storage_protect.node_file_backup:
+    backup_action: "selective"
+    filespec: "/root/backup_test/"
+    is_subdir: "yes"
+    files_only: "yes"
+...
+'''
+
+from ..module_utils.dsmc_adapter import DsmcAdapter
+
+def main():
+    argument_spec = dict(
+        backup_action=dict(required=True, choices=['selective', 'incremental']),
+        filespec=dict(required=True),
+        absolute=dict(),
+        is_compression_enabled=dict(),
+        is_compress_always=dict(),
+        diff_snapshot=dict(),
+        dirs_only=dict(),
+        file_list=dict(),
+        files_only=dict(),
+        remove_operand_limit=dict(),
+        snapshot_root=dict(),
+        is_subdir=dict(),
+        server_name=dict(),
+        node_name=dict(),
+        password=dict(),
+        request_timeout=dict(),
+
+    )
+    module = DsmcAdapter(argument_spec=argument_spec, supports_check_mode=True)
+    backup_action = module.params.get('backup_action')
+    filespec = module.params.get('filespec')
+    option_params = {
+        'absolute': 'absolute',
+        'is_compression_enabled': 'compression',
+        'is_compress_always': 'compressalways',
+        'diff_snapshot': 'diffsnapshot',
+        'dirs_only': 'dirsonly',
+        'file_list': 'filelist',
+        'files_only': 'filesonly',
+        'remove_operand_limit': 'removeoperandlimit',
+        'snapshot_root': 'snapshotroot',
+        'is_subdir': 'subdir',
+    }
+    option_params_no_value = [
+        "absolute",
+        "filesonly",
+        "dirsonly",
+        "removeoperandlimit",
+    ]
+    options = ''
+    for opt in option_params.keys():
+        value = module.params.get(opt)
+        if value is not None:
+            value = str(value)
+            if option_params[opt] in option_params_no_value:
+                if value.lower() == "yes":
+                    options += f" -{option_params[opt]}"
+            else:
+                options += f" -{option_params[opt]}={value}"
+
+    rc, output, error = module.perform_action(backup_action, filespec, options)
+
+if __name__ == "__main__":
+    main()

--- a/roles/node_file_backup/README.md
+++ b/roles/node_file_backup/README.md
@@ -1,0 +1,59 @@
+# ibm.storage_protect.backup
+
+## Description
+An ansible role to take on demand backup on Storage protect client.
+
+## Requirements 
+- Ansible 2.9+ 
+- IBM Storage Protect server configured and accessible  and atleast one BA client node registered with server.
+
+## Environment Variables
+
+Before running the playbook, set the following environment variables in your terminal:
+
+```bash
+export STORAGE_PROTECT_SERVERNAME="<Storage protect server name that client is registered with>"
+export STORAGE_PROTECT_NODENAME="<Node name registered with storage protect server>"
+export STORAGE_PROTECT_NODE_PASSWORD="<Node password of the node that is registered with storage protect server"
+```
+
+## Variables
+The following role variables are child of storage_protect_node_file_backup.
+
+|Variable Name|Default Value|Required|Description|
+|:---|:---:|:---:|:---|
+|`backup_action`||yes|Backup type (selective/incremental)|
+|`filespec`||yes|The paths of the files or directories to backup.Supports list of multiple files and directories, separated by a space character;in addition,use wildcard characters to include a group of files or to include all files in a directory.| 
+|`absolute`||no|Use the absolute variable with the incremental command to force a backup of all files and directories that match the file specification or domain,even if the objects were not changed since the last incremental backup.Setting to a value of "Yes" will enable the mentioned functionality.|
+|`compression`||no|The compression variable compresses files before you send them to the server.Use with the incremental,and selective commands.Setting to a value of "Yes" will enable the compression. A value of "No" will ensure files are not compressed. |
+|`is_compress_always`||no|Use this variable together with is_compression_enabled. When is_compression_enabled is set to "Yes", the is_compress_always variable specifies whether to continue compressing an object if it grows during compression.Setting to a velue of "Yes" will continue to compress an object even if size of object grows after compression. Setting to a value of "No" will send the file uncompressed if the file size increases.Use with the incremental, and selective commands.|
+|`diff_snapshot`||no|The diff_snapshot variable controls whether the backup-archive client creates the differential snapshot when it runs a snapshot difference incremental backup. Use with incremental command.If value is set to "create"  backup-archive client will create the snapshot during incremental backup. If the value it set to "latest" client will use the latest snapshot that is found on the file server as source snapshot.|
+|`dirs_only`||no|The dirs_only variable when set to "Yes" processes directories only during backup. The client does not process files. Use with incremental and selective command.|
+|`file_list`||no|Use the file_list variable to process a list of files. The backup-archive client opens the file you specify with this variable and processes the list of files within according to the specific command.Use with incremental and selective command.|
+|`files_only`||no|The files_only variable when set to "Yes" restricts backup processing to files only. Use with incremental and selective comand.|
+|`remove_operand_limit`||no|The remove_operand_limit variable specifies that the client removes the 20-operand limit as this limits the number of files and directories that can be specified with command.Use with incremental and selective commands.Setting the value to "Yes" will remove the limit.|
+|`snapshot_root`||no|Use the snapshot_root variable with the incremental, selective, commands to specify the root directory of snapshot that should be used for backup.This option is used in snapshot-supported environments. With this mechanism backup only processes snapshot data and not live filesystem. For ex : dsmc incremental /mnt/snapshot1/data -snapshotroot=/mnt/snapshot1|
+|`is_subdir`||no|The subdir variable specifies whether you want to include subdirectories of named directories for processing.If set to "Yes" subdirectories are processed otherwise not.Use with incremental and selective commands.|
+
+
+## Example Playbooks
+```yaml
+- name: Take on demand backup in IBM Storage Protect
+  hosts: storage_protect_client 
+  roles:
+    - role: ibm.storage_protect.node_file_backup 
+      vars:
+	storage_protect_node_file_backup:
+          backup_action: "selective" 
+          filespec: "/root/ODB" 
+          is_subdir: "yes"
+```
+
+
+## License Information
+Apache License, Version 2.0
+
+See [LICENSE](LICENSE) for the full license text.
+
+## Author
+[Amol kumar](https://github.com/amol-kumar1) 

--- a/roles/node_file_backup/meta/main.yml
+++ b/roles/node_file_backup/meta/main.yml
@@ -1,0 +1,20 @@
+---
+galaxy_info:
+  role_name: backup 
+  author: Amol kumar 
+  description: "Ansible role to take on-demand back up in IBM storage protect."
+  license: MIT
+  min_ansible_version: 2.15.0
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies:
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+  - role: global_vars
+...

--- a/roles/node_file_backup/tasks/main.yml
+++ b/roles/node_file_backup/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- name: "Storage Protect On demand backup"
+  ibm.storage_protect.node_file_backup:
+    backup_action: "{{storage_protect_node_file_backup.backup_action | mandatory}}"
+    filespec: "{{storage_protect_node_file_backup.filespec | mandatory}}"
+    absolute: "{{storage_protect_node_file_backup.absolute | default(omit)}}"
+    compression: "{{storage_protect_node_file_backup.compression | default(omit)}}"
+    is_compress_always: "{{storage_protect_node_file_backup.is_compress_always | default(omit)}}"
+    diff_snapshot: "{{storage_protect_node_file_backup.diff_snapshot | default(omit)}}"
+    dirs_only: "{{storage_protect_node_file_backup.dirs_only | default(omit)}}"
+    file_list: "{{storage_protect_node_file_backup.file_list | default(omit)}}"
+    files_only: "{{storage_protect_node_file_backup.files_only | default(omit)}}"
+    remove_operand_limit: "{{storage_protect_node_file_backup.remove_operand_limit | default(omit)}}"
+    snapshot_root: "{{storage_protect_node_file_backup.snapshot_root | default(omit)}}"
+    is_subdir: "{{storage_protect_node_file_backup.is_subdir | default(omit)}}"
+
+
+    # Role Standard Options
+    server_name: "{{ storage_protect_server_name | default(omit) }}"
+    node_name: "{{ storage_protect_node_name | default(omit) }}"
+    password: "{{ storage_protect_node_password | default(omit) }}"
+    request_timeout: "{{ storage_protect_request_timeout | default(omit) }}"
+
+  register: backup_status
+- name: Debug output
+  debug:
+    var: backup_status

--- a/tests/integration/targets/node_file_backup/test_on_demand_backup.yml
+++ b/tests/integration/targets/node_file_backup/test_on_demand_backup.yml
@@ -1,0 +1,20 @@
+---
+- name: Test On Demand backup in IBM Storage Protect
+  hosts: storage_protect_client
+  vars:
+    storage_protect_server_name: "{{ lookup('env', 'STORAGE_PROTECT_SERVERNAME') }}"
+    storage_protect_node_name: "{{ lookup('env', 'STORAGE_PROTECT_NODENAME') }}"
+    storage_protect_node_password: "{{ lookup('env', 'STORAGE_PROTECT_NODE_PASSWORD') }}"
+    storage_protect_node_file_backup:
+      backup_action: "selective"
+      filespec: "/root/backup_test/"
+      is_subdir: "yes"
+
+  roles:
+    - ibm.storage_protect.node_file_backup
+
+  tasks:
+    - name: "Verify the Result of the backup Taken"
+      ansible.builtin.debug:
+        msg: "Backup test completed successfully."
+...


### PR DESCRIPTION


## PR summary
This PR introduces role for taking an on-demand backup in IBM storage protect server. It also adds modules and module utils to achieve the goal. 

**Fixes:** <! -- link to issue -->

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
Ansible Role to take an on-demand backup on Storage Protect Server does not exist.

## What is the new behavior?  
This PR adds the role for taking an on-demand backup on Storage Protect Server. The role uses custom backup module written to take backup. The module uses dsmc_adapter utility module which runs dsmc command on BA client to take a backup.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

This PR is raised to resolve the verified commit issue. The link to the original PR where review happened is here.
https://github.com/IBM/ansible-storage-protect/pull/20

##Test Results


1. Transfer of a 763 MB file
TASK [backup : Debug output] ************************************************************************************************************************************************************************************************************************
ok: [fenrirloki-vm98] => {
"backup_status": {
"changed": true,
"command": "dsmc selective /root/backup_test/ -filesonly -se=cabin4 -virtualnode=fenrir98 -pass=fenrir98 ",
"failed": false,
"output": "IBM Storage Protect\nCommand Line Backup-Archive Client Interface\n Client Version 8, Release 1, Level 23.0 \n Client date/time: 01/24/25 01:00:46\n(c) Copyright by IBM Corporation and other(s) 1990, 2024. All Rights Reserved. \n\nNode Name: FENRIR98\nSession established with server CABIN4: AIX\n Server Version 8, Release 1, Level 25.000\n Server date/time: 01/24/25 00:55:54 Last access: 01/24/25 00:49:56\n\nSelective Backup function invoked.\n\nNormal File--> 132,517,560 /root/backup_test/TIVsm-BA.x86_64.rpm [Sent]\nNormal File--> 667,791,360 /root/backup_test/8.1.23.0-TIV-TSMBAC-LinuxX86.tar [Sent]\nSelective Backup processing of '/root/backup_test/*' finished without failure.\n\n\nTotal number of objects inspected: 2\nTotal number of objects backed up: 2\nTotal number of objects updated: 0\nTotal number of objects rebound: 0\nTotal number of objects deleted: 0\nTotal number of objects expired: 0\nTotal number of objects failed: 0\nTotal number of objects encrypted: 0\nTotal number of objects grew: 0\nTotal number of retries: 0\nTotal number of bytes inspected: 763.23 MB\nTotal number of bytes transferred: 763.26 MB\nData transfer time: 7.30 sec\nNetwork data transfer rate: 106,969.49 KB/sec\nAggregate data transfer rate: 94,398.71 KB/sec\nObjects compressed by: 0%\nTotal data reduction ratio: 0.00%\nElapsed processing time: 00:00:08\n",
"warnings": [
"Module did not set no_log for password"
]
}
}

TASK [Verify the Result of the backup Taken] ********************************************************************************************************************************************************************************************************
ok: [fenrirloki-vm98] => {
"msg": "Backup test completed successfully."
}

Use of incremental command on previously backed up file which remained unchanged. 0 bytes transferred.
TASK [backup : Debug output] ************************************************************************************************************************************************************************************************************************
ok: [fenrirloki-vm98] => {
"backup_status": {
"changed": true,
"command": "dsmc incremental /root/backup_test/ -filesonly -subdir=yes -se=cabin4 -virtualnode=fenrir98 -pass=fenrir98 ",
"failed": false,
"output": "IBM Storage Protect\nCommand Line Backup-Archive Client Interface\n Client Version 8, Release 1, Level 23.0 \n Client date/time: 01/24/25 01:03:10\n(c) Copyright by IBM Corporation and other(s) 1990, 2024. All Rights Reserved. \n\nNode Name: FENRIR98\nSession established with server CABIN4: AIX\n Server Version 8, Release 1, Level 25.000\n Server date/time: 01/24/25 00:58:18 Last access: 01/24/25 00:55:55\n\n\nIncremental backup of volume '/root/backup_test/'\nSuccessful incremental backup of '/root/backup_test/*'\n\n\nTotal number of objects inspected: 4\nTotal number of objects backed up: 0\nTotal number of objects updated: 0\nTotal number of objects rebound: 0\nTotal number of objects deleted: 0\nTotal number of objects expired: 0\nTotal number of objects failed: 0\nTotal number of objects encrypted: 0\nTotal number of objects grew: 0\nTotal number of retries: 0\nTotal number of bytes inspected: 763.58 MB\nTotal number of bytes transferred: 0 B\nData transfer time: 0.00 sec\nNetwork data transfer rate: 0.00 KB/sec\nAggregate data transfer rate: 0.00 KB/sec\nObjects compressed by: 0%\nTotal data reduction ratio: 100.00%\nElapsed processing time: 00:00:01\n",
"warnings": [
"Module did not set no_log for password"
]
}
}

TASK [Verify the Result of the backup Taken] ********************************************************************************************************************************************************************************************************
ok: [fenrirloki-vm98] => {
"msg": "Backup test completed successfully."
}

File/Directory path not valid
TASK [ibm.storage_protect.backup : Storage Protect On demand backup] ********************************************************************************************************************************************************************************
[WARNING]: Module did not set no_log for password
fatal: [fenrirloki-vm98]: FAILED! => {"changed": false, "command": "dsmc selective /root/backup/ -se=cabin4 -virtualnode=fenrir98 -pass=fenrir98 ", "msg": "IBM Storage Protect\nCommand Line Backup-Archive Client Interface\n Client Version 8, Release 1, Level 23.0 \n Client date/time: 01/27/25 10:32:14\n(c) Copyright by IBM Corporation and other(s) 1990, 2024. All Rights Reserved. \n\nNode Name: FENRIR98\nSession established with server CABIN4: AIX\n Server Version 8, Release 1, Level 25.000\n Server date/time: 01/27/25 10:27:21 Last access: 01/27/25 10:23:40\n\nSelective Backup function invoked.\n\nANS1076E The specified directory path '/root/backup/*' could not be found.\n", "rc": 12}
PLAY RECAP ******************************************************************************************************************************************************************************************************************************************
fenrirloki-vm98 : ok=1 changed=0 unreachable=0 failed=1 skipped=0 rescued=0 ignored=0

Server out of storage space
TASK [ibm.storage_protect.backup : Storage Protect On demand backup] ********************************************************************************************************************************************************************************
[WARNING]: Module did not set no_log for password
fatal: [fenrirloki-vm98]: FAILED! => {"changed": false, "command": "dsmc selective /root/backup_test/ -subdir=yes -se=cabin4 -virtualnode=fenrir98 -pass=fenrir98 ", "msg": "IBM Storage Protect\nCommand Line Backup-Archive Client Interface\n Client Version 8, Release 1, Level 23.0 \n Client date/time: 01/27/25 10:34:21\n(c) Copyright by IBM Corporation and other(s) 1990, 2024. All Rights Reserved. \n\nNode Name: FENRIR98\nSession established with server CABIN4: AIX\n Server Version 8, Release 1, Level 25.000\n Server date/time: 01/27/25 10:29:27 Last access: 01/27/25 10:27:21\n\nSelective Backup function invoked.\n\nDirectory--> 85 /root/backup_test [Sent]\nDirectory--> 41 /root/backup_test/amol [Sent]\nNormal File--> 132,517,560 /root/backup_test/TIVsm-BA.x86_64.rpm ** Unsuccessful **\nANS1228E Sending of object '/root/backup_test/TIVsm-BA.x86_64.rpm' failed.\nANS1311E Server out of data storage space\n\nNormal File--> 667,791,360 /root/backup_test/8.1.23.0-TIV-TSMBAC-LinuxX86.tar ** Unsuccessful **\nANS1228E Sending of object '/root/backup_test/8.1.23.0-TIV-TSMBAC-LinuxX86.tar' failed.\nANS1311E Server out of data storage space\n\nDirectory--> 26 /root/backup_test/amol/another [Sent]\nNormal File--> 181,467 /root/backup_test/amol/another/dsminstr.log [Sent]\nNormal File--> 181,467 /root/backup_test/amol/dsminstr.log [Sent]\nRetry # 1 Directory--> 26 /root/backup_test/amol/another [Sent]\nRetry # 1 Normal File--> 181,467 /root/backup_test/amol/another/dsminstr.log ** Unsuccessful **\nANS1228E Sending of object '/root/backup_test/amol/another/dsminstr.log' failed.\nANS1311E Server out of data storage space\n\nRetry # 1 Normal File--> 181,467 /root/backup_test/amol/dsminstr.log ** Unsuccessful **\nANS1228E Sending of object '/root/backup_test/amol/dsminstr.log' failed.\nANS1311E Server out of data storage space\n\nANS1804E Selective Backup processing of '/root/backup_test/*' finished with failures.\n\n\nTotal number of objects inspected: 7\nTotal number of objects backed up: 3\nTotal number of objects updated: 0\nTotal number of objects rebound: 0\nTotal number of objects deleted: 0\nTotal number of objects expired: 0\nTotal number of objects failed: 4\nTotal number of objects encrypted: 0\nTotal number of objects grew: 0\nTotal number of retries: 3\nTotal number of bytes inspected: 763.58 MB\nTotal number of bytes transferred: 649.32 MB\nData transfer time: 3.52 sec\nNetwork data transfer rate: 188,443.77 KB/sec\nAggregate data transfer rate: 153,360.27 KB/sec\nObjects compressed by: 0%\nTotal data reduction ratio: 14.97%\nElapsed processing time: 00:00:04\nANS1311E Server out of data storage space\n\n", "rc": 12}

PLAY RECAP ******************************************************************************************************************************************************************************************************************************************
fenrirloki-vm98 : ok=1 changed=0 unreachable=0 failed=1 skipped=0 rescued=0 ignored=0 
