### PR TITLE
Added a module to Configure OC 

### DIFF
--- a/playbooks/oc_configure/oc_configure.yml
+++ b/playbooks/oc_configure/oc_configure.yml
@@ -1,0 +1,7 @@
+---
+- name: Perform OC operation
+  hosts: "{{ target_hosts | default('all') }}"
+  become: true
+  roles:
+    - oc_configure
+...

--- a/plugins/modules/oc_configure.py
+++ b/plugins/modules/oc_configure.py
@@ -49,7 +49,7 @@ def main():
     )
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-    dsmadmc_adapter = DsmadmcAdapter()
+    dsmadmc_adapter = DsmadmcAdapter(argument_spec=argument_spec)
 
     admin_name = module.params['admin_name']
     action = module.params['action']

--- a/plugins/modules/oc_configure.py
+++ b/plugins/modules/oc_configure.py
@@ -33,10 +33,12 @@ EXAMPLES='''
   ibm.storage_protect.oc_configure:
     admin_name: tsmuser1
     action: configure
+
 - name: Stop OC
   ibm.storage_protect.oc_configure:
     admin_name: tsmuser1
     action: stop
+
 - name: Start OC
   ibm.storage_protect.oc_configure:
     admin_name: tsmuser1
@@ -44,7 +46,7 @@ EXAMPLES='''
 '''
 def main():
     argument_spec = dict(
-        admin_name=dict(type='str', required=True),
+        admin_name=dict(type='str', required=False),
         action=dict(type='str', required=True, choices=['configure', 'restart', 'stop'])
     )
 
@@ -53,6 +55,9 @@ def main():
 
     admin_name = module.params['admin_name']
     action = module.params['action']
+
+    if action == 'configure' and not admin_name:
+        module.fail_json(msg="'admin_name' is required when action is 'configure'")
 
     rc, out, err = module.run_command('systemctl status opscenter.service')
 

--- a/plugins/modules/oc_configure.py
+++ b/plugins/modules/oc_configure.py
@@ -1,0 +1,89 @@
+from ansible.module_utils.basic import AnsibleModule
+from ..module_utils.dsmadmc_adapter import DsmadmcAdapter
+
+DOCUMENTATION='''
+---
+module: oc_configure
+author: Sarthak Kshirsagar
+short_description: Configure, stop, or restart IBM Storage Protect Operations Center
+description:
+  - Configures IBM Storage Protect Operations Center.
+  - Stops or restarts the Operations Center (OC) service.
+options:
+  admin_name:
+    description:
+      - The name of the admin user of the hub server.
+    required: true
+    type: str
+  action:
+    description:
+      - The action to be performed using this module.
+    required: true
+    type: str
+    choices:
+      - configure
+      - restart
+      - stop
+
+'''
+
+EXAMPLES='''
+---
+- name: Configure OC
+  ibm.storage_protect.oc_configure:
+    admin_name: tsmuser1
+    action: configure
+- name: Stop OC
+  ibm.storage_protect.oc_configure:
+    admin_name: tsmuser1
+    action: stop
+- name: Start OC
+  ibm.storage_protect.oc_configure:
+    admin_name: tsmuser1
+    action: restart
+'''
+def main():
+    argument_spec = dict(
+        admin_name=dict(type='str', required=True),
+        action=dict(type='str', required=True, choices=['configure', 'restart', 'stop'])
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    dsmadmc_adapter = DsmadmcAdapter()
+
+    admin_name = module.params['admin_name']
+    action = module.params['action']
+
+    rc, out, err = module.run_command('systemctl status opscenter.service')
+
+    if 'could not be found' in (out + err).lower() or 'not-found' in (out + err).lower():
+        module.fail_json(msg="OC is not installed or service is not registered.")
+
+    if action == 'configure':
+        rc, out, err = dsmadmc_adapter.run_command(
+            f'update admin {admin_name} sessionsecurity=transitional',
+            auto_exit=False
+        )
+        if rc == 0:
+            module.exit_json(
+                msg="OC configuration complete. Access the OC at https://<hostname>:<port>/oc",
+                stdout=out,
+                changed=False
+            )
+        else:
+            module.fail_json(msg='Failed to configure the OC', stdout=out, stderr=str(err))
+
+    else:
+        rc, out, err = module.run_command(["systemctl", action, "opscenter.service"])
+        if rc == 0:
+            module.exit_json(changed=True,stdout=out,tderr=err)
+        else:
+            module.fail_json(
+                msg=f'Failed to {action} the OC',
+                stdout=out,
+                stderr=err,
+                changed=False
+            )
+
+if __name__ == '__main__':
+    main()

--- a/roles/oc_configure/README.md
+++ b/roles/oc_configure/README.md
@@ -3,10 +3,11 @@
 ## Overview
 An Ansible role to configure, restart, or stop IBM Storage Protect Operations Center.
 
+## Requirements
+1. Client should be installed and registered with the server.
+
 ## Environment Variables
-
 Before running the playbook, set the following environment variables in your terminal:
-
 ```bash
 export STORAGE_PROTECT_SERVERNAME="your_server_name"
 export STORAGE_PROTECT_USERNAME="your_username"

--- a/roles/oc_configure/README.md
+++ b/roles/oc_configure/README.md
@@ -1,0 +1,40 @@
+# ibm.storage_protect.oc_configure
+
+## Overview
+An Ansible role to configure, restart, or stop IBM Storage Protect Operations Center.
+
+## Environment Variables
+
+Before running the playbook, set the following environment variables in your terminal:
+
+```bash
+export STORAGE_PROTECT_SERVERNAME="your_server_name"
+export STORAGE_PROTECT_USERNAME="your_username"
+export STORAGE_PROTECT_PASSWORD="your_password"
+```
+
+## Role Variables
+
+| Variable     | Default | Description                           |
+|--------------|---------|---------------------------------------|
+| `admin_name` | ""      | OC admin username (only for configure) |
+| `action`     | restart | Action to perform (configure, restart, stop) |
+
+## Example Playbook
+
+```yaml
+---
+- name: Configure OC
+  hosts: localhost
+  become: yes
+  roles:
+    - role: oc_configure
+      vars:
+        admin_name: tsmadmin
+        action: configure
+```
+
+# Sample playbook is available in playbooks directory of ibm/storage_protect github repo
+```bash
+ansible-playbook playbooks/oc_configure/oc_configure.yml -e "target_hosts=host_group action=configure admin_name=tsmuser1"
+```

--- a/roles/oc_configure/README.md
+++ b/roles/oc_configure/README.md
@@ -15,10 +15,10 @@ export STORAGE_PROTECT_PASSWORD="your_password"
 
 ## Role Variables
 
-| Variable     | Default | Description                           |
-|--------------|---------|---------------------------------------|
-| `admin_name` | ""      | OC admin username (only for configure) |
-| `action`     | restart | Action to perform (configure, restart, stop) |
+| Variable     | Default | Description                                          |
+|--------------|---------|------------------------------------------------------|
+| `admin_name` | ""      | OC admin username (Required, if action == configure) |
+| `action`     | restart | Action to perform (configure, restart, stop)         |
 
 ## Example Playbook
 
@@ -32,6 +32,22 @@ export STORAGE_PROTECT_PASSWORD="your_password"
       vars:
         admin_name: tsmadmin
         action: configure
+
+- name: Stop OC
+  hosts: localhost
+  become: yes
+  roles:
+    - role: oc_configure
+      vars:
+        action: stop
+
+- name: Configure OC
+  hosts: localhost
+  become: yes
+  roles:
+    - role: oc_configure
+      vars:
+        action: restart
 ```
 
 # Sample playbook is available in playbooks directory of ibm/storage_protect github repo

--- a/roles/oc_configure/defaults/main.yml
+++ b/roles/oc_configure/defaults/main.yml
@@ -1,0 +1,4 @@
+# Defaults for the role
+
+admin_name: ""
+action: "configure"

--- a/roles/oc_configure/meta/main.yml
+++ b/roles/oc_configure/meta/main.yml
@@ -1,0 +1,21 @@
+---
+galaxy_info:
+  role_name: oc_configure
+  author: Sarthak Kshirsagar
+  description: "This Ansible role configures,restart and stop the IBM Storage Protect Operations Center."
+  license: MIT
+  min_ansible_version: 2.15.0
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies:
+#  - role: system_info
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.
+#  - role: global_vars
+...

--- a/roles/oc_configure/tasks/main.yml
+++ b/roles/oc_configure/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: Perform OC operation
+  oc_configure:
+    admin_name: "{{ admin_name }}"
+    action: "{{ action }}"

--- a/tests/integration/targets/oc_configure/test_oc_configure.yml
+++ b/tests/integration/targets/oc_configure/test_oc_configure.yml
@@ -1,0 +1,7 @@
+---
+- name: Perform OC operation
+  hosts: "{{ target_hosts | default('all') }}"
+  become: true
+  roles:
+    - ibm.storage_protect.oc_configure
+...


### PR DESCRIPTION
## PR summary
This PR adds a new module to configure the IBM Storage Protect Operations Center.
**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [✓] The commit message follows the Commit Message Guidelines in the CONTRIBUTING.md.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [✓] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [✓] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [✓] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
Currently Operations center is installed using ibm.storage_protect.sp_server_install role. However admin cannot access Operations center.

## What is the new behavior?  
This PR adds a new module to configure IBM Storage Protect OC. In order to access the OC, the admin user on the server, accessing the oc, should set  'sessionsecurity' to 'transitional' and then need to start the oc service. This modules takes the name of the admin, server's dsmadmc credentials, and the action to be performed on OC and accordingly configures, stop or restart the oc. 

## Does this PR introduce a breaking change?    
- [ ] Yes
- [✓] No


## Output Screenshots
![image](https://github.com/user-attachments/assets/01c9737b-046f-40a9-8a05-620a8db11664)



