### PR TITLE
Improve uninstallation feedback by displaying list of removed components

### DIFF
--- a/roles/sp_server_install/tasks/sp_server_uninstall_linux.yml
+++ b/roles/sp_server_install/tasks/sp_server_uninstall_linux.yml
@@ -40,11 +40,11 @@
         uninstalled_components: >-
           {{
             [
-              (offerings.server and sp_server_state == "absent") | ternary("SP Server", None),
-              (offerings.oc and sp_server_state == "absent") | ternary("Operations Center", None),
-              (offerings.ossm and sp_server_state == "absent") | ternary("OSSM", None),
-              (offerings.stagent and sp_server_state == "absent") | ternary("Storage Agent", None),
-              (offerings.devices and sp_server_state == "absent") | ternary("Devices", None)
+              (offerings.server and sp_server_state == "absent") | ternary("SP Server", ""),
+              (offerings.oc and sp_server_state == "absent") | ternary("Operations Center", ""),
+              (offerings.ossm and sp_server_state == "absent") | ternary("OSSM", ""),
+              (offerings.stagent and sp_server_state == "absent") | ternary("Storage Agent", ""),
+              (offerings.devices and sp_server_state == "absent") | ternary("Devices", "")
             ] | select('defined') | list
           }}
   rescue:

--- a/roles/sp_server_install/tasks/sp_server_uninstall_linux.yml
+++ b/roles/sp_server_install/tasks/sp_server_uninstall_linux.yml
@@ -45,7 +45,7 @@
               (offerings.ossm and sp_server_state == "absent") | ternary("OSSM", ""),
               (offerings.stagent and sp_server_state == "absent") | ternary("Storage Agent", ""),
               (offerings.devices and sp_server_state == "absent") | ternary("Devices", "")
-            ] | select('defined') | list
+            ] | select('defined') | select() | list
           }}
   rescue:
     - name: Uninstallation Failed

--- a/roles/sp_server_install/tasks/sp_server_uninstall_linux.yml
+++ b/roles/sp_server_install/tasks/sp_server_uninstall_linux.yml
@@ -28,10 +28,25 @@
         - "/tsm/server/*/*"
       when: sp_server_state == "absent"
 
+#    - name: Uninstallation Status
+#      ansible.builtin.debug:
+#        msg:
+#          - "Successfully uninstalled SP Server"
+
     - name: Uninstallation Status
       ansible.builtin.debug:
-        msg:
-          - "Successfully uninstalled SP Server"
+        msg: "Successfully uninstalled: {{ uninstalled_components | join(', ') }}"
+      vars:
+        uninstalled_components: >-
+          {{
+            [
+              (offerings.server and sp_server_state == "absent") | ternary("SP Server", None),
+              (offerings.oc and oc_state == "absent") | ternary("Operations Center", None),
+              (offerings.ossm and ossm_state == "absent") | ternary("OSSM", None),
+              (offerings.stagent and stagent_state == "absent") | ternary("Storage Agent", None),
+              (offerings.devices and devices_state == "absent") | ternary("Devices", None)
+            ] | select('defined') | list
+          }}
   rescue:
     - name: Uninstallation Failed
       ansible.builtin.debug:

--- a/roles/sp_server_install/tasks/sp_server_uninstall_linux.yml
+++ b/roles/sp_server_install/tasks/sp_server_uninstall_linux.yml
@@ -41,10 +41,10 @@
           {{
             [
               (offerings.server and sp_server_state == "absent") | ternary("SP Server", None),
-              (offerings.oc and oc_state == "absent") | ternary("Operations Center", None),
-              (offerings.ossm and ossm_state == "absent") | ternary("OSSM", None),
-              (offerings.stagent and stagent_state == "absent") | ternary("Storage Agent", None),
-              (offerings.devices and devices_state == "absent") | ternary("Devices", None)
+              (offerings.oc and sp_server_state == "absent") | ternary("Operations Center", None),
+              (offerings.ossm and sp_server_state == "absent") | ternary("OSSM", None),
+              (offerings.stagent and sp_server_state == "absent") | ternary("Storage Agent", None),
+              (offerings.devices and sp_server_state == "absent") | ternary("Devices", None)
             ] | select('defined') | list
           }}
   rescue:


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->

**Fixes:** 
https://github.com/IBM/ansible-storage-protect/issues/36#issuecomment-2849955374

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [✓] The commit message follows the Commit Message Guidelines in the CONTRIBUTING.md.
- [✓] Tests for the changes have been added (for bug fixes / features)
- [✓] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [✓] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
sp-server-install role does not show the list of uninstalled components.

## What is the new behavior?  
Modified the debug messages to show the list of uninstalled components.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [✓] No

<img width="1728" alt="Screenshot 2025-05-05 at 4 37 48 PM" src="https://github.com/user-attachments/assets/01b2dcdf-7540-4c13-896f-da3a5f1fce97" />