### PR TITLE
Extended BA Client Facts module for AIX Platform

### DIFF
--- a/playbooks/ba_client_install/playbooks/aix/ba_client_facts_playbook.yml
+++ b/playbooks/ba_client_install/playbooks/aix/ba_client_facts_playbook.yml
@@ -1,0 +1,35 @@
+---
+- name: Gather IBM Storage Protect BA Client Facts on AIX
+  hosts: aix_clients
+  gather_facts: yes
+
+  vars:
+    # BA Client connection details
+    storage_protect_servername: "{{ server_name }}"
+    storage_protect_nodename: "{{ ansible_hostname }}"
+    storage_protect_admin_user: "{{ admin }}"
+    storage_protect_admin_password: "{{ admin_password }}"
+
+  tasks:
+    - name: Gather all BA Client facts
+      ba_client_facts:
+        server_name: "{{ storage_protect_servername }}"
+        node_name: "{{ storage_protect_nodename }}"
+        user_id: "{{ storage_protect_admin_user }}"
+        password: "{{ storage_protect_admin_password }}"
+        q_version: true
+        q_session: true
+        q_schedule: true
+        q_filespace: true
+        q_systeminfo: true
+      register: ba_client_facts
+
+    - name: Display BA Client facts
+      debug:
+        var: ba_client_facts
+
+    - name: Save BA Client facts to file
+      copy:
+        content: "{{ ba_client_facts | to_nice_json }}"
+        dest: "/tmp/ba_client_facts_{{ ansible_hostname }}.json"
+      when: ba_client_facts is defined

--- a/plugins/module_utils/ba_client_facts.py
+++ b/plugins/module_utils/ba_client_facts.py
@@ -50,10 +50,19 @@ class DsmcAdapterExtended(DsmcAdapter):
             tuple: (return_code, stdout, stderr)
         """
         # Build the command based on platform
-        is_windows = platform.system().lower().startswith("win")
+        system_platform = platform.system().lower()
+        is_windows = system_platform.startswith("win")
+        is_aix = system_platform == "aix"
         
         if is_windows:
             dsmc_cmd = 'dsmc.exe'
+        elif is_aix:
+            # AIX: Try to find DSMC in common locations
+            dsmc_cmd = self._find_dsmc_aix()
+            if not dsmc_cmd:
+                if exit_on_fail:
+                    self.fail_json(msg="DSMC not found on AIX system. Checked: /usr/bin/dsmc, /opt/tivoli/tsm/client/ba/bin/dsmc, /usr/tivoli/tsm/client/ba/bin/dsmc")
+                return 1, "", "DSMC not found"
         else:
             dsmc_cmd = 'dsmc'
         
@@ -70,6 +79,14 @@ class DsmcAdapterExtended(DsmcAdapter):
         # Prepare input for interactive prompts (user ID and password)
         input_data = f"{user_id}\n{password}\n"
         
+        # AIX-specific environment setup
+        env = None
+        if is_aix:
+            import os
+            env = os.environ.copy()
+            env['LANG'] = 'C'  # Ensure English output for consistent parsing
+            env['LC_ALL'] = 'C'
+        
         try:
             result = subprocess.run(
                 full_command,
@@ -78,7 +95,8 @@ class DsmcAdapterExtended(DsmcAdapter):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-                timeout=30
+                timeout=30,
+                env=env
             )
             raw_output = result.stdout
             self.json_output['output'] = raw_output
@@ -105,7 +123,26 @@ class DsmcAdapterExtended(DsmcAdapter):
                     **self.json_output
                 )
             return e.returncode, None, e.stderr
-
+    
+    def _find_dsmc_aix(self):
+        """
+        Find DSMC binary on AIX system.
+        
+        Returns:
+            str: Path to DSMC binary or None if not found
+        """
+        import os
+        possible_paths = [
+            '/usr/bin/dsmc',
+            '/opt/tivoli/tsm/client/ba/bin/dsmc',
+            '/usr/tivoli/tsm/client/ba/bin/dsmc'
+        ]
+        
+        for path in possible_paths:
+            if os.path.exists(path) and os.access(path, os.X_OK):
+                return path
+        
+        return None
 
 class DSMCParser:
     """

--- a/plugins/modules/ba_client_facts.py
+++ b/plugins/modules/ba_client_facts.py
@@ -39,7 +39,7 @@ description:
     - This module gathers various facts related to the IBM Storage Protect (SP) Backup-Archive (BA) Client using the DSMC command-line interface.
     - It supports multiple queries such as client version, configuration, schedules, file spaces, and backup status.
     - The output of each query is parsed and returned in a developer-friendly format.
-    - Works on both Linux and Windows platforms.
+    - Works on Linux, Windows, and AIX platforms.
 
 options:
     q_version:
@@ -221,11 +221,13 @@ def build_windows_like_module():
 def get_module():
     """
     Return an object that has the Ansible-like interface.
-    - on Linux/Ansible: real DsmcAdapterExtended
+    - on Linux/AIX/Ansible: real DsmcAdapterExtended
     - on Windows/no-ansible: our shim
     """
-    if HAS_ANSIBLE and platform.system().lower() != "windows":
-        # Original behavior
+    system_platform = platform.system().lower()
+    
+    if HAS_ANSIBLE and system_platform not in ["windows", "win32"]:
+        # Linux, AIX, or other Unix-like systems with Ansible
         argument_spec = dict(
             q_version=dict(type='bool', default=False),
             q_session=dict(type='bool', default=False),


### PR DESCRIPTION
## PR summary
Extended BA Client Facts module for AIX Platform

**Fixes:** [SDDEVOPS-2251](https://jsw.ibm.com/browse/SDDEVOPS-2251)

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the Commit Message Guidelines in the CONTRIBUTING.md.
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  

- The `ba_client_facts` module only supports Linux and Windows platforms, failing when executed on AIX systems

## What is the new behavior?  

- The `ba_client_facts` module now supports AIX platform with automatic DSMC binary discovery
- AIX administrators can gather all BA Client facts (version, session, schedules, filespaces, etc.) using consistent Ansible playbooks across Linux, Windows, and AIX.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
